### PR TITLE
c++11

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,4 @@
 from conans import ConanFile
-import os
 
 
 class ArghConan(ConanFile):

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -4,5 +4,6 @@ cmake_minimum_required(VERSION 2.8.11)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+set (CMAKE_CXX_STANDARD 11)
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})


### PR DESCRIPTION
The ``conan create`` command will fail if the compiler doesn't use C++11 by default (gcc 5, etc)
Also, the ``import os`` is unused.

Altough it is strictly not necessary to re-create and re-upload the package, it would be nice, as the system detects that the recipe has been changed, and mark the final packages "outdated" from the recipe.

Thanks!