### PR TITLE
Add argh interface library for CMake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,10 @@ cmake_minimum_required(VERSION 3.1)
 
 set (CMAKE_CXX_STANDARD 11)
 
-add_executable(argh       example.cpp)
-add_executable(argh_tests argh_tests.cpp)
+add_executable(argh_example example.cpp)
+add_executable(argh_tests   argh_tests.cpp)
+add_library(argh INTERFACE)
+target_include_directories(argh INTERFACE "${CMAKE_CURRENT_LIST_DIR}")
 
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT argh_tests)
 


### PR DESCRIPTION
Adds an `argh` interface library target so users can consume the library in CMake by linking to the lib.
The example executable was renamed to `argh_example`.