### PR TITLE
Minor fixes, enhanced multi-options

### DIFF
--- a/argh.h
+++ b/argh.h
@@ -147,6 +147,7 @@ namespace argh
       bool is_number(std::string const& arg) const;
       bool is_option(std::string const& arg) const;
       bool got_flag(std::string const& name) const;
+      bool is_param(std::string const& name) const;
 
    private:
       std::vector<std::string> args_;
@@ -197,13 +198,26 @@ namespace argh
          }
 
          // if the option is unregistered and should be a multi-flag
-         if (1 == (args_[i].size() - name.size()) &&                  // single dash
-            argh::parser::SINGLE_DASH_IS_MULTIFLAG & mode &&         // multi-flag mode
-            registeredParams_.find(name) == registeredParams_.end()) // unregistered
+         if (1 == (args_[i].size() - name.size()) &&         // single dash
+            argh::parser::SINGLE_DASH_IS_MULTIFLAG & mode && // multi-flag mode
+            !is_param(name))                                  // unregistered
          {
+            std::string keep_param; 
+            
+            if (!name.empty() && is_param(std::string(1ul, name.back()))) // last char is param
+            {
+               keep_param += name.back();
+               name.resize(name.size() - 1);
+            }
+
             for (auto const& c : name)
             {
                flags_.emplace(std::string{ c });
+            }
+
+            if (!keep_param.empty())
+            {
+               name = keep_param;
             }
          }
 
@@ -223,7 +237,7 @@ namespace argh
          // PREFER_PARAM_FOR_UNREG_OPTION: a non-registered 'name' is determined a parameter, the next arg
          //                                will be the value of that option.
 
-         if (registeredParams_.find(name) != registeredParams_.end() ||
+         if (is_param(name) ||
             argh::parser::PREFER_PARAM_FOR_UNREG_OPTION & mode)
          {
             params_.insert({ name, args_[i + 1] });
@@ -279,6 +293,13 @@ namespace argh
    inline bool argh::parser::got_flag(std::string const& name) const
    {
       return flags_.end() != flags_.find(trim_leading_dashes(name));
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline bool argh::parser::is_param(std::string const& name) const
+   {
+      return registeredParams_.count(name);
    }
 
    //////////////////////////////////////////////////////////////////////////

--- a/argh.h
+++ b/argh.h
@@ -237,6 +237,9 @@ namespace argh
          // PREFER_PARAM_FOR_UNREG_OPTION: a non-registered 'name' is determined a parameter, the next arg
          //                                will be the value of that option.
 
+         assert(!(mode & argh::parser::PREFER_FLAG_FOR_UNREG_OPTION)
+             || !(mode & argh::parser::PREFER_PARAM_FOR_UNREG_OPTION));
+
          if (is_param(name) ||
             argh::parser::PREFER_PARAM_FOR_UNREG_OPTION & mode)
          {

--- a/argh.h
+++ b/argh.h
@@ -244,16 +244,18 @@ namespace argh
          assert(!(mode & argh::parser::PREFER_FLAG_FOR_UNREG_OPTION)
              || !(mode & argh::parser::PREFER_PARAM_FOR_UNREG_OPTION));
 
-         if (is_param(name) ||
-            argh::parser::PREFER_PARAM_FOR_UNREG_OPTION & mode)
+         bool preferParam = mode & argh::parser::PREFER_PARAM_FOR_UNREG_OPTION;
+
+         if (is_param(name) || preferParam)
          {
             params_.insert({ name, args_[i + 1] });
             ++i; // skip next value, it is not a free parameter
             continue;
          }
-
-         if (argh::parser::PREFER_FLAG_FOR_UNREG_OPTION & mode)
+         else
+         {
             flags_.emplace(name);
+         }
       };
    }
 

--- a/argh.h
+++ b/argh.h
@@ -219,6 +219,10 @@ namespace argh
             {
                name = keep_param;
             }
+            else
+            {
+               continue; // do not consider other options for this arg
+            }
          }
 
          // any potential option will get as its value the next arg, unless that arg is an option too

--- a/argh_tests.cpp
+++ b/argh_tests.cpp
@@ -341,12 +341,11 @@ TEST_CASE("Interpret single-dash arg as multi-flag")
 
         CHECK(cmdl["x"]);
         CHECK(cmdl["v"]);
-        CHECK(cmdl["f"]);
+        CHECK(cmdl("f").str() == "42");
 
         CHECK(cmdl["abc"]);
-        CHECK(cmdl.pos_args().size() == 2);
-        CHECK(cmdl.pos_args().at(0) == "42");
-        CHECK(cmdl.pos_args().at(1) == "54");
+        CHECK(cmdl.pos_args().size() == 1);
+        CHECK(cmdl.pos_args().at(0) == "54");
         CHECK(!cmdl["a"]);
         CHECK(!cmdl["b"]);
         CHECK(!cmdl["c"]);

--- a/argh_tests.cpp
+++ b/argh_tests.cpp
@@ -329,6 +329,24 @@ TEST_CASE("Interpret single-dash arg as multi-flag")
         CHECK(cmdl["v"]);
         CHECK(cmdl["f"]);
 
+        CHECK(cmdl("abc").str() == "54");
+        CHECK(!cmdl["a"]);
+        CHECK(!cmdl["b"]);
+        CHECK(!cmdl["c"]);
+    }
+    {
+        parser cmdl;
+        cmdl.add_param("f");
+        cmdl.parse(argc, argv, parser::PREFER_FLAG_FOR_UNREG_OPTION | parser::SINGLE_DASH_IS_MULTIFLAG);
+
+        CHECK(cmdl["x"]);
+        CHECK(cmdl["v"]);
+        CHECK(cmdl["f"]);
+
+        CHECK(cmdl["abc"]);
+        CHECK(cmdl.pos_args().size() == 2);
+        CHECK(cmdl.pos_args().at(0) == "42");
+        CHECK(cmdl.pos_args().at(1) == "54");
         CHECK(!cmdl["a"]);
         CHECK(!cmdl["b"]);
         CHECK(!cmdl["c"]);

--- a/argh_tests.cpp
+++ b/argh_tests.cpp
@@ -330,6 +330,8 @@ TEST_CASE("Interpret single-dash arg as multi-flag")
         CHECK(cmdl["f"]);
 
         CHECK(cmdl("abc").str() == "54");
+        CHECK(cmdl.pos_args().size() == 1);
+        CHECK(cmdl.pos_args().at(0) == "42");
         CHECK(!cmdl["a"]);
         CHECK(!cmdl["b"]);
         CHECK(!cmdl["c"]);

--- a/argh_tests.cpp
+++ b/argh_tests.cpp
@@ -337,20 +337,27 @@ TEST_CASE("Interpret single-dash arg as multi-flag")
         CHECK(!cmdl["c"]);
     }
     {
-        parser cmdl;
-        cmdl.add_param("f");
-        cmdl.parse(argc, argv, parser::PREFER_FLAG_FOR_UNREG_OPTION | parser::SINGLE_DASH_IS_MULTIFLAG);
+        int modes[] = { 
+            parser::SINGLE_DASH_IS_MULTIFLAG, // flags preferred by default
+            parser::PREFER_FLAG_FOR_UNREG_OPTION | parser::SINGLE_DASH_IS_MULTIFLAG,
+        };
+        for (int mode : modes)
+        {
+            parser cmdl;
+            cmdl.add_param("f");
+            cmdl.parse(argc, argv, mode);
 
-        CHECK(cmdl["x"]);
-        CHECK(cmdl["v"]);
-        CHECK(cmdl("f").str() == "42");
+            CHECK(cmdl["x"]);
+            CHECK(cmdl["v"]);
+            CHECK(cmdl("f").str() == "42");
 
-        CHECK(cmdl["abc"]);
-        CHECK(cmdl.pos_args().size() == 1);
-        CHECK(cmdl.pos_args().at(0) == "54");
-        CHECK(!cmdl["a"]);
-        CHECK(!cmdl["b"]);
-        CHECK(!cmdl["c"]);
+            CHECK(cmdl["abc"]);
+            CHECK(cmdl.pos_args().size() == 1);
+            CHECK(cmdl.pos_args().at(0) == "54");
+            CHECK(!cmdl["a"]);
+            CHECK(!cmdl["b"]);
+            CHECK(!cmdl["c"]);
+        }
     }
     {
         parser cmdl;


### PR DESCRIPTION
As [invited per twitter](https://twitter.com/AdiShavit/status/1014610398606254083), my tests & implementation.

Meanwhile, stumbled on a number of minor issues, which I've also fixed.

On the [remark](https://twitter.com/AdiShavit/status/1014609958183297024):

> Otoh it IS called SINGLE_DASH_IS_MULTI*FLAG*

I can only say what the commit message to adcc89e9b118fb39f89ffe3a4a127cf574661f27 also says:

>  Note: This is consistent with the existing special case of _just_ `-f`, which was already treated as a parameter option.
