### PR TITLE
Buck build support

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,5 @@
+[project]
+ignore = .git
+
+[cxx]
+should_remap_host_platform = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build/
 .vs/
+buck-out/
+.buckd/
+.buckconfig.local

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,35 @@
+prebuilt_cxx_library(
+  name = 'argh', 
+  header_namespace = '', 
+  header_only = True, 
+  exported_headers = [
+    'argh.h', 
+  ], 
+  visibility = [
+    'PUBLIC', 
+  ], 
+)
+
+cxx_binary(
+  name = 'tests', 
+  header_namespace = '', 
+  headers = [
+    'doctest.h', 
+  ], 
+  srcs = [
+    'argh_tests.cpp', 
+  ], 
+  deps = [
+    ':argh', 
+  ], 
+)
+
+cxx_binary(
+  name = 'example', 
+  srcs = [
+    'example.cpp', 
+  ], 
+  deps = [
+    ':argh', 
+  ], 
+)

--- a/README.md
+++ b/README.md
@@ -291,6 +291,25 @@ target_link_libraries(${MY_TARGET_NAME} argh)
 
 ```
 
+## Buck
+
+The [Buck](https://buckbuild.com/) build system is also supported. 
+
+Run the example: 
+
+```bash=
+buck run :example
+```
+
+Run the tests: 
+
+```bash=
+buck run :tests
+buck run test_package
+```
+
+If you take `argh` as a submodule, then the visible target is `argh`. 
+
 ## Colophon
 
 I ❤ your feedback. If you found Argh! useful - do Tweet about it to let [me](https://twitter.com/AdiShavit) know. If you found it lacking, please post an [issue](https://github.com/adishavit/argh/issues).

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ buck run :tests
 buck run test_package
 ```
 
-If you take `argh` as a submodule, then the visible target is `argh`. 
+If you take `argh` as a submodule, then the visible target is `//:argh`. 
 
 ## Colophon
 

--- a/test_package/BUCK
+++ b/test_package/BUCK
@@ -1,0 +1,9 @@
+cxx_binary(
+  name = 'test_package', 
+  srcs = [
+    'test_package.cpp', 
+  ], 
+  deps = [
+    '//:argh', 
+  ], 
+)


### PR DESCRIPTION
Hello! :wave:

This PR adds support for the [Buck](https://buckbuild.com/) build system. Whilst this library is header-only, the Buck file serves as instructions for integrating the headers into other libraries. I also ported the tests + examples. The existing CMake build is left unchanged. 

https://github.com/LoopPerfect/buckaroo-wishlist/issues/114