### PR TITLE
Make the bool conversion operator explicit

### DIFF
--- a/argh.h
+++ b/argh.h
@@ -60,7 +60,7 @@ namespace argh
 
       // Check the state of the stream.
       // False when the most recent stream operation failed
-      operator bool() const { return !!stream_; }
+      explicit operator bool() const { return !!stream_; }
 
       ~stringstream_proxy() = default;
    private:


### PR DESCRIPTION
Avoids accidental conversions to/from int because of integer promotion.
Also, matches the std::istringstream bool operator declaration.