### PR TITLE
argh: Fix an implicit sign conversion

### DIFF
--- a/argh.h
+++ b/argh.h
@@ -174,7 +174,7 @@ namespace argh
    inline void parser::parse(int argc, const char* const argv[], int mode /*= PREFER_FLAG_FOR_UNREG_OPTION*/)
    {
       // convert to strings
-      args_.resize(argc);
+      args_.resize(static_cast<decltype(args_)::size_type>(argc));
       std::transform(argv, argv + argc, args_.begin(), [](const char* const arg) { return arg;  });
 
       // parse line


### PR DESCRIPTION
First of all, thanks for this library! It's a real pleasure to use.

This PR fixes a _tiny_ warning in `parser::parse` -- it turns an implicit sign conversion into an explicit one via `static_cast`. It also uses `decltype` to be as explicit as possible about what it's casting to, but I can replace that with the decomposed type (`unsigned long` or `std::size_t`) if you'd like.