### PR TITLE
Moving set_property of target argh_test where the target is defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,12 +28,11 @@ endif()
 if(BUILD_TESTS)
 	add_executable(argh_tests   argh_tests.cpp)
 	target_compile_options(argh_tests PRIVATE ${flags})
+	set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT argh_tests)
 endif()
 
 add_library(argh INTERFACE)
 target_include_directories(argh INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include>)
-
-set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT argh_tests)
 
 if(ARGH_MASTER_PROJECT)
 	install(TARGETS argh EXPORT arghTargets)


### PR DESCRIPTION
Otherwise it would generated the following warning

```
CMake Warning (dev) in build/_deps/argh-src/CMakeLists.txt:
  Directory property VS_STARTUP_PROJECT specifies target 'argh_tests' that
  does not exist.  Ignoring.
This warning is for project developers.  Use -Wno-dev to suppress it.
```