### PR TITLE
Make add_params and add_param compatible with each other.

### DIFF
--- a/argh.h
+++ b/argh.h
@@ -110,6 +110,9 @@ namespace argh
       {  parse(argc, argv, mode); }
 
       void add_param(std::string const& name);
+      void add_params(std::string const& name);
+
+      void add_param(std::initializer_list<char const* const> init_list);
       void add_params(std::initializer_list<char const* const> init_list);
 
       void parse(const char* const argv[], int mode = PREFER_FLAG_FOR_UNREG_OPTION);
@@ -452,10 +455,24 @@ namespace argh
 
    //////////////////////////////////////////////////////////////////////////
 
+   inline void parser::add_param(std::initializer_list<const char *const> init_list)
+   {
+       parser::add_params(init_list);
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
    inline void parser::add_params(std::initializer_list<char const* const> init_list)
    {
       for (auto& name : init_list)
          registeredParams_.insert(trim_leading_dashes(name));
+   }
+
+   //////////////////////////////////////////////////////////////////////////
+
+   inline void parser::add_params(const std::string &name)
+   {
+       parser::add_param(name);
    }
 
    //////////////////////////////////////////////////////////////////////////

--- a/argh_tests.cpp
+++ b/argh_tests.cpp
@@ -861,3 +861,25 @@ TEST_CASE("Test adding duplicate flags")
 	 }
 }
 
+TEST_CASE("Test parsing single with add_params")
+{
+    const char fixture[] = "abc-123";
+    const char* argv[] = { "-a",fixture, nullptr };
+    parser cmdl;
+    cmdl.add_params("a");
+    cmdl.parse(argv);
+
+    CHECK(fixture == cmdl({"a"}).str());
+}
+
+TEST_CASE("Test parsing multiple with add_param")
+{
+    const char fixture[] = "abc-123";
+    const char* argv[] = { "-a",fixture, "-b", "2", "-c", "3", nullptr };
+    parser cmdl;
+    cmdl.add_param({"a", "b", "c"});
+    cmdl.parse(argv);
+
+    CHECK(cmdl({"a", "b", "c"}));
+    CHECK(fixture == cmdl({"a"}).str());
+}


### PR DESCRIPTION
Reference: #49

For ease-of-use, make the add_param method and the add_params method interchangeable. Allowing either to be called with multiple or single parameters.

Each of the newly created methods simply calls the original version, preventing the need for wide-spread changes in the future.