### PR TITLE
Fix building tests on PPC

### DIFF
--- a/doctest.h
+++ b/doctest.h
@@ -370,6 +370,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26812) // Prefer 'enum class' over 'enum'
 #elif defined(DOCTEST_PLATFORM_MAC)
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT (hicpp-no-assembler)
+#elif defined(__POWERPC__)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n" \
+        : : : "memory","r0","r3","r4" ) // NOLINT
 #else
 #define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT (hicpp-no-assembler)
 #endif


### PR DESCRIPTION
Without this the build fails badly with multiple assembler errors:
```
{standard input}:66102:Invalid mnemonic 'brk'
```
With the patch, all tests pass:
```
--->  Testing arghandler
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_devel_arghandler/arghandler/work/build" && ./argh_tests 
[doctest] doctest version is "2.4.6"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:  29 |  29 passed | 0 failed | 0 skipped
[doctest] assertions: 367 | 367 passed | 0 failed |
[doctest] Status: SUCCESS!
```

P. S. I had to rename the port, since we already have `argh` in Macports.