### PR TITLE
[parser::params] add overload accepting std::initializer_list

### DIFF
--- a/argh.h
+++ b/argh.h
@@ -8,6 +8,7 @@
 #include <set>
 #include <map>
 #include <cassert>
+#include <ranges>
 
 namespace argh
 {
@@ -121,6 +122,7 @@ namespace argh
       std::multiset<std::string>               const& flags()    const { return flags_;    }
       std::multimap<std::string, std::string>  const& params()   const { return params_;   }
       multimap_iteration_wrapper                      params(std::string const& name) const;
+      auto                                            params(std::initializer_list<char const* const> init_list) const;
       std::vector<std::string>                 const& pos_args() const { return pos_args_; }
 
       // begin() and end() for using range-for over positional args.
@@ -481,5 +483,14 @@ namespace argh
    {
       auto trimmed_name = trim_leading_dashes(name);
       return multimap_iteration_wrapper(params_.lower_bound(trimmed_name), params_.upper_bound(trimmed_name));
+   }
+
+   inline auto parser::params(std::initializer_list<char const* const> init_list) const
+   {
+      return std::ranges::subrange( init_list.begin(), init_list.end() ) |
+         std::views::transform( [ this ]( char const * const name ) -> multimap_iteration_wrapper {
+            return this->params( std::string( name ) );
+         } ) |
+         std::views::join;
    }
 }

--- a/argh.h
+++ b/argh.h
@@ -8,7 +8,14 @@
 #include <set>
 #include <map>
 #include <cassert>
-#include <ranges>
+
+#if __cplusplus >= 201703L && __has_include( <version> )
+#  include <version> // for library features tests
+#endif
+
+#if defined( __cpp_lib_ranges )
+#  include <ranges>
+#endif
 
 namespace argh
 {
@@ -122,7 +129,9 @@ namespace argh
       std::multiset<std::string>               const& flags()    const { return flags_;    }
       std::multimap<std::string, std::string>  const& params()   const { return params_;   }
       multimap_iteration_wrapper                      params(std::string const& name) const;
+#if defined( __cpp_lib_ranges )
       auto                                            params(std::initializer_list<char const* const> init_list) const;
+#endif
       std::vector<std::string>                 const& pos_args() const { return pos_args_; }
 
       // begin() and end() for using range-for over positional args.
@@ -485,6 +494,9 @@ namespace argh
       return multimap_iteration_wrapper(params_.lower_bound(trimmed_name), params_.upper_bound(trimmed_name));
    }
 
+   //////////////////////////////////////////////////////////////////////////
+
+#if defined( __cpp_lib_ranges )
    inline auto parser::params(std::initializer_list<char const* const> init_list) const
    {
       return std::ranges::subrange( init_list.begin(), init_list.end() ) |
@@ -493,4 +505,5 @@ namespace argh
          } ) |
          std::views::join;
    }
+#endif
 }


### PR DESCRIPTION
Allows calling `cmdl.params( { "--name", "-n" } )` and getting all relevant values, regardless of which param name was used on the command line. For example,
```c++
std::ranges::for_each(
   cmdl.params( { "--name", "-n" } ) | std::views::values,
   []( const std::string& value ) {
      // do something with the parameter value
    } );
```

Since the implementation uses `std::ranges`, perhaps it's a good idea to conditionally enable it only for c++>=20 and feature test [`__cpp_lib_ranges`](https://en.cppreference.com/w/cpp/feature_test); I know some projects prefer making equivalent tests in the build system and setting a compiler definition accordingly, any thoughts?

Also, this implementation requires that the parser's lifetime exceeds that of the return value -- `this` gets captured in the lambda -- which to me seems natural in most use cases, and a reasonable thing to require (and document). The alternative would be making a copy of the data...