### PR TITLE
CMake: update minimum cmake version to avoid warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(argh)
 


### PR DESCRIPTION
CMake 3.27 issued a deprecation warning saying cmake <3.5 would no longer be supported.

closes #86