### PR TITLE
Add CMake 3.14 to 4.0 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14...4.0)
 
-project(argh)
+project(argh LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 


### PR DESCRIPTION
Project builds (with pre-existing deprecation warnings). All tests pass.